### PR TITLE
Include LICENSE file in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+license_file = LICENSE
+
 [versioneer]
 VCS = git
 versionfile_source = pyctdev/_version.py


### PR DESCRIPTION
The license requires that all copies of the software include the license.  This makes sure the license is included in the wheels.  See the wheel documentation [here](https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file) for more information.