### PR TITLE
Pinning conda below 4.6

### DIFF
--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -250,7 +250,6 @@ def task_ecosystem_setup():
 
     return {
         'actions': [
-            CmdAction(thing1),
             CmdAction(thing2)
         ],
         'params': [_channel_param]}

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup_args = dict(
         # not sure exactly which versions
         # (actually, cb pin is for tested/known good version
         # TODO: beware pin here and in _conda.py!
-        'ecosystem_conda': ['conda >=4.4', 'conda-build ==3.10.1']
+        'ecosystem_conda': ['conda <4.6', 'conda-build ==3.10.1']
     }
 )
 


### PR DESCRIPTION
We are seeing errors on appveyor builds that appear to be due to a new version of conda. @philippjfr and I discussed doing a patch release straight to the pyviz channel with this pinning. This would be called version 0.5.2