### PR TITLE
Fix mapping recipe

### DIFF
--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -756,6 +756,8 @@ def task_package_build():
             )
             f.write("{%% set builddeps = %s %%}\n" % buildeps)
             f.write("{%% set need_tests_deps = %s %%}\n" % pkg_tests)
+            namespace_map = read_conda_namespace_map("setup.cfg")
+            f.write("{%% set namespace_map = %s %%}\n" % namespace_map)
             f.write(r)
 
     def create_recipe_clobber(recipe, pin_deps_as_env, no_pin_deps, package_name):

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -829,8 +829,6 @@ def task_package_build():
             cmd += (
                 " --clobber-file conda.recipe/%s/_pyctdev_recipe_clobber.yaml" % recipe
             )
-        print('START 4')
-        print(cmd)
         return cmd
 
     def thing2(
@@ -933,23 +931,16 @@ def task_package_build():
         "actions": [
             # 0. install build requirements (conda build doesn't support pyproject.toml/PEP518
             CmdAction(thing0),
-            'echo 1',
             create_base_recipe,
-            'echo 2',
             create_recipe_clobber,
-            'echo 3',
             # first build the package...
             CmdAction(thing),
-            'echo 4',
             "conda build purge",  # remove test/work intermediates (disk space on travis...but could potentially annoy someone as it'll remove other test/work intermediates too...)
-            'echo 5',
             # then test it...
             # (if test commands overlap what's in recipe, will be some
             #  repetition...they ran above, and they will run again...)
             create_recipe_append,
-            'echo 6',
             CmdAction(thing2),
-            'echo 7',
         ],
         "teardown": [remove_recipe_append_and_clobber],
         "params": [

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -710,7 +710,7 @@ def task_package_build():
 
     force = {"name": "force", "long": "force", "type": bool, "default": False}
 
-    def create_base_recipe(package_name, force):
+    def create_base_recipe(package_name, force, pkg_tests):
 
         # TODO: need to replace this with checking for existing recipe and using that.
         # and fall back to package name in normal setup.cfg
@@ -755,6 +755,7 @@ def task_package_build():
                 "[" + ",".join('"%s"' % _join_the_club(dep) for dep in buildreqs) + "]"
             )
             f.write("{%% set builddeps = %s %%}\n" % buildeps)
+            f.write("{%% set need_tests_deps = %s %%}\n" % pkg_tests)
             f.write(r)
 
     def create_recipe_clobber(recipe, pin_deps_as_env, no_pin_deps, package_name):
@@ -826,6 +827,8 @@ def task_package_build():
             cmd += (
                 " --clobber-file conda.recipe/%s/_pyctdev_recipe_clobber.yaml" % recipe
             )
+        print('START 4')
+        print(cmd)
         return cmd
 
     def thing2(
@@ -928,16 +931,23 @@ def task_package_build():
         "actions": [
             # 0. install build requirements (conda build doesn't support pyproject.toml/PEP518
             CmdAction(thing0),
+            'echo 1',
             create_base_recipe,
+            'echo 2',
             create_recipe_clobber,
+            'echo 3',
             # first build the package...
             CmdAction(thing),
+            'echo 4',
             "conda build purge",  # remove test/work intermediates (disk space on travis...but could potentially annoy someone as it'll remove other test/work intermediates too...)
+            'echo 5',
             # then test it...
             # (if test commands overlap what's in recipe, will be some
             #  repetition...they ran above, and they will run again...)
             create_recipe_append,
+            'echo 6',
             CmdAction(thing2),
+            'echo 7',
         ],
         "teardown": [remove_recipe_append_and_clobber],
         "params": [

--- a/pyctdev/condatemplate.yaml
+++ b/pyctdev/condatemplate.yaml
@@ -27,12 +27,12 @@ requirements:
     - python {{ sdata.get('python_requires','') }}
 
     {% for dep in sdata.get('install_requires',[]) %}
-    - "{{ dep }}"
+    - "{{ namespace_map.get(dep, dep) }}"
     {% endfor %}
 
     {% for extra in extras %}
      {% for dep in sdata.get('extras_require',{}).get(extra,[]) %}
-    - "{{ dep }}"
+    - "{{ namespace_map.get(dep, dep) }}"
      {% endfor %}
     {% endfor %}
 
@@ -42,7 +42,7 @@ test:
   {%if need_tests_deps %}
   requires:
     {% for dep in sdata['extras_require']['tests'] %}
-    - "{{ dep }}"
+    - "{{ namespace_map.get(dep, dep) }}"
     {% endfor %}
   {% endif %}
 

--- a/pyctdev/condatemplate.yaml
+++ b/pyctdev/condatemplate.yaml
@@ -39,10 +39,12 @@ requirements:
 test:
   imports:
     - {{ pname }}
+  {%if need_tests_deps %}
   requires:
     {% for dep in sdata['extras_require']['tests'] %}
     - "{{ dep }}"
     {% endfor %}
+  {% endif %}
 
 about:
   home: {{ sdata['url'] }}


### PR DESCRIPTION
Changes to how the template recipe is handled:

- the tests dependencies were included even if `doit package_build` was called with `--no-pkg-tests`
- the pip-to-conda mapping wasn't used, it's now injected in the template